### PR TITLE
typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This implementation supports:
 ## Install
 
 ```scala
-libraryDependencies += "dev.kovstas" % "fs2-throttler" % Version
+libraryDependencies += "dev.kovstas" %% "fs2-throttler" % Version
 ```
 
 ## Usage


### PR DESCRIPTION
scala dependencies should use `%%` so sbt can add either `_2.12` `_2.13` or whatever